### PR TITLE
Added case name prefix to optimization history file

### DIFF
--- a/src/fortran/airfoil_evaluation.f90
+++ b/src/fortran/airfoil_evaluation.f90
@@ -994,7 +994,7 @@ function write_function_restart_cleanup(restart_status, global_search,         &
                                                    moment, xtrt, xtrb
   double precision, dimension(:), allocatable :: fmin, relfmin, rad
   character(150), dimension(:), allocatable :: zoneinfo
-  character(100) :: restfile, foilfile, polarfile, text
+  character(100) :: restfile, foilfile, polarfile, histfile, text
   character(11) :: stepchar
   character(20) :: fminchar, radchar
   character(25) :: relfminchar
@@ -1105,7 +1105,8 @@ function write_function_restart_cleanup(restart_status, global_search,         &
 
 ! Open history file
 
-  open(unit=histunit, file='optimization_history.dat', status='old',           &
+  histfile = trim(output_prefix)//'_optimization_history.dat'
+  open(unit=histunit, file=histfile, status='old',           &
        iostat=ioerr)
   if (ioerr /= 0) then
     write_function_restart_cleanup = 3
@@ -1128,7 +1129,7 @@ function write_function_restart_cleanup(restart_status, global_search,         &
 
 ! Re-write history file without the unused iterations
 
-  open(unit=histunit, file='optimization_history.dat', status='replace')
+  open(unit=histunit, file=histfile, status='replace')
   write(histunit,'(A)') "Iteration  Objective function  "//&
                         "% Improvement over seed  Design radius"
   do i = 1, step

--- a/src/fortran/genetic_algorithm.f90
+++ b/src/fortran/genetic_algorithm.f90
@@ -86,6 +86,7 @@ subroutine geneticalgorithm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax, &
   use optimization_util, only : init_random_seed, initial_designs,             &
                                 design_radius, write_design, bubble_sort,      &
                                 read_run_control
+  use vardef, only : output_prefix
 
   double precision, dimension(:), intent(inout) :: xopt
   double precision, intent(out) :: fmin
@@ -130,6 +131,7 @@ subroutine geneticalgorithm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax, &
   character(20) :: fminchar, radchar
   character(25) :: relfminchar
   character(80), dimension(20) :: commands
+  character(100) :: histfile
 
   nconstrained = size(constrained_dvs,1)
 
@@ -197,13 +199,13 @@ subroutine geneticalgorithm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax, &
   end if
 
 ! Open file for writing iteration history
-
+  histfile = trim(output_prefix)//'_optimization_history.dat'
   iunit = 17
   new_history_file = .false.
   if (step == 0) then
     new_history_file = .true.
   else
-    open(unit=iunit, file='optimization_history.dat', status='old',            &
+    open(unit=iunit, file=histfile, status='old',            &
          position='append', iostat=ioerr)
     if (ioerr /= 0) then
       write(*,*) 
@@ -214,7 +216,7 @@ subroutine geneticalgorithm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax, &
     end if
   end if
   if (new_history_file) then
-    open(unit=iunit, file='optimization_history.dat', status='replace')
+    open(unit=iunit, file=histfile, status='replace')
     if (ga_options%relative_fmin_report) then
       write(iunit,'(A)') "Iteration  Objective function  "//&
                          "% Improvement over seed  Design radius"

--- a/src/fortran/particle_swarm.f90
+++ b/src/fortran/particle_swarm.f90
@@ -64,6 +64,7 @@ subroutine particleswarm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax,    &
   use math_deps,         only : norm_2
   use optimization_util, only : init_random_seed, initial_designs,             &
                                 design_radius, write_design, read_run_control
+  use vardef, only : output_prefix
 
   double precision, dimension(:), intent(inout) :: xopt
   double precision, intent(out) :: fmin
@@ -105,6 +106,7 @@ subroutine particleswarm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax,    &
   character(20) :: fminchar, radchar
   character(25) :: relfminchar
   character(80), dimension(20) :: commands
+  character(100) :: histfile
 
   nconstrained = size(constrained_dvs,1)
 
@@ -214,13 +216,13 @@ subroutine particleswarm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax,    &
   end if
 
 ! Open file for writing iteration history
-
+  histfile = trim(output_prefix)//'_optimization_history.dat'
   iunit = 17
   new_history_file = .false.
   if (step == 0) then
     new_history_file = .true.
   else
-    open(unit=iunit, file='optimization_history.dat', status='old',            &
+    open(unit=iunit, file=histfile, status='old',            &
          position='append', iostat=ioerr)
     if (ioerr /= 0) then
       write(*,*) 
@@ -231,7 +233,7 @@ subroutine particleswarm(xopt, fmin, step, fevals, objfunc, x0, xmin, xmax,    &
     end if
   end if
   if (new_history_file) then
-    open(unit=iunit, file='optimization_history.dat', status='replace')
+    open(unit=iunit, file=histfile, status='replace')
     if (pso_options%relative_fmin_report) then
       write(iunit,'(A)') "Iteration  Objective function  "//&
                          "% Improvement over seed  Design radius"

--- a/src/fortran/simplex_search.f90
+++ b/src/fortran/simplex_search.f90
@@ -49,6 +49,8 @@ subroutine simplexsearch(xopt, fmin, step, fevals, objfunc, x0, given_f0_ref,  &
   use optimization_util, only : bubble_sort, design_radius, write_design,      &
                                 read_run_control
 
+  use vardef, only : output_prefix
+
   double precision, dimension(:), intent(inout) :: xopt
   double precision, intent(out) :: fmin
   integer, intent(out) :: step, fevals
@@ -87,6 +89,7 @@ subroutine simplexsearch(xopt, fmin, step, fevals, objfunc, x0, given_f0_ref,  &
   character(20) :: fminchar, radchar
   character(25) :: relfminchar
   character(80), dimension(20) :: commands
+  character(100) :: histfile
 
 ! Standard Nelder-Mead constants
 
@@ -162,13 +165,13 @@ subroutine simplexsearch(xopt, fmin, step, fevals, objfunc, x0, given_f0_ref,  &
   mincurr = fmin
 
 ! Open file for writing iteration history
-
+  histfile = trim(output_prefix)//'_optimization_history.dat'
   iunit = 17
   new_history_file = .false.
   if ( (prevsteps == 0) .and. (step == 0) ) then
     new_history_file = .true.
   else
-    open(unit=iunit, file='optimization_history.dat', status='old',            &
+    open(unit=iunit, file=histfile, status='old',            &
          position='append', iostat=ioerr)
     if (ioerr /= 0) then
       write(*,*) 
@@ -179,7 +182,7 @@ subroutine simplexsearch(xopt, fmin, step, fevals, objfunc, x0, given_f0_ref,  &
     end if
   end if
   if (new_history_file) then
-    open(unit=iunit, file='optimization_history.dat', status='replace')
+    open(unit=iunit, file=histfile, status='replace')
     if (ds_options%relative_fmin_report) then
       write(iunit,'(A)') "Iteration  Objective function  "//&
                          "% Improvement over seed  Design radius"

--- a/src/python/xoptfoil_visualizer.py
+++ b/src/python/xoptfoil_visualizer.py
@@ -225,7 +225,7 @@ def read_airfoil_polars(filename, zonetitle):
 
 ################################################################################
 # Reads optimization history
-def read_optimization_history(step):
+def read_optimization_history(histfilename, step):
 
   ioerror = 0
   fmin = 0.
@@ -235,7 +235,7 @@ def read_optimization_history(step):
   # Try to open the file
 
   try:
-    f = open('optimization_history.dat') 
+    f = open(histfilename) 
   except IOError:
     ioerror = 1
     return fmin, relfmin, rad, ioerror
@@ -907,7 +907,7 @@ def read_new_optimization_history(steps=None, fmins=None, relfmins=None,
   
     # Read data from optimization history file
   
-    fmin, relfmin, rad, ioerror = read_optimization_history(nextstep)
+    fmin, relfmin, rad, ioerror = read_optimization_history(histfilename, nextstep)
     if (ioerror == 1):
       print("optimization_history.dat not available yet.")
       reading = False
@@ -1291,6 +1291,7 @@ if __name__ == "__main__":
 
   coordfilename = prefix + '_design_coordinates.dat'
   polarfilename = prefix + '_design_polars.dat'
+  histfilename  = prefix + '_optimization_history.dat'
 
   # Read airfoil coordinates and polars
 


### PR DESCRIPTION
Existing code uses a case name prefix for files such as the design coordinates and polars, but not the optimization history.  This means that if multiple sequential optimization runs are conducted, only the most recent optimisation history is available for subsequent review.  The proposed PR adds the case name prefix to the optimization history file to overcome this.

Note: code has not been compiled or tested - I do not have Linux nor MinGQ and my last Fortran coding was in 1989, but it shouldn't be far from working code...